### PR TITLE
Fix Celo Metamask error

### DIFF
--- a/packages/huma-shared/src/utils/chain.ts
+++ b/packages/huma-shared/src/utils/chain.ts
@@ -87,8 +87,8 @@ export const CHAINS: {
   },
   [ChainEnum.Celo]: {
     id: ChainEnum.Celo,
-    urls: ['https://rpc.ankr.com/celo'],
-    name: 'Celo',
+    urls: ['https://forno.celo.org'],
+    name: 'Celo Mainnet',
     nativeCurrency: CELO,
     explorer: 'https://celoscan.io',
     wait: 1,


### PR DESCRIPTION
Metamask shows errors that the network name "Celo" does not match up with what's associated with this provider. Changing it to "Celo Mainnet" fixes the error.