### PR TITLE
Fix integer overflow for large decimal ERC20 tokens and incorrect chain ID for widget provider

### DIFF
--- a/packages/huma-shared/src/utils/pool.ts
+++ b/packages/huma-shared/src/utils/pool.ts
@@ -393,6 +393,25 @@ export const PoolContractMap: PoolContractMapType = {
           disableBorrow: true,
         },
       },
+      [POOL_NAME.HumaCreditLine]: {
+        basePoolConfig: '0x0bb39a0136643d60244070619e2e8ecbddf038ae',
+        pool: '0xB6958E6852E1dA4C2468d8c0286884C68519282a',
+        poolFeeManager: '0xd6fB372Da1c157Ca769dd1bD33D3e59D1B8376d0',
+        poolUnderlyingToken: {
+          address: '0x5F9E8b946472C9bA78491a4AbeA9d3BAccfB28E5',
+          symbol: 'USDC',
+          decimals: 18,
+          icon: 'USDC',
+        },
+        poolName: POOL_NAME.HumaCreditLine,
+        poolType: POOL_TYPE.CreditLine,
+        poolAbi: BASE_CREDIT_POOL_ABI,
+        basePoolConfigAbi: BASE_POOL_CONFIG_ABI,
+        HDT: {
+          address: '0x25BB64Ee818fFb2ee04c18D829a3754bDbfb4802',
+          abi: HDT_ABI,
+        },
+      },
     },
   },
   [ChainEnum.Celo]: {
@@ -418,7 +437,7 @@ export const PoolContractMap: PoolContractMapType = {
         extra: {
           disableBorrow: true,
           detailsPage: true,
-          borrower: '0xA5bbE69085bAB0E75B71fc3aBdeaC1cBaAf93e4c',
+          borrower: '0x10FB65dc26a7aCC7CFB4eA3b6E007c8C77591486',
         },
       },
     },

--- a/packages/huma-widget/src/components/CreditLine/borrow/2-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/CreditLine/borrow/2-ChooseAmount.tsx
@@ -1,12 +1,12 @@
 import {
   AccountStats,
   PoolInfoType,
-  upScale,
   useCLFeeManager,
   useCLPoolAllowance,
 } from '@huma-finance/shared'
 import { useWeb3React } from '@web3-react/core'
 import React, { useCallback, useState } from 'react'
+import { BigNumber } from 'ethers'
 
 import { useAppDispatch } from '../../../hooks/useRedux'
 import { setBorrowInfo } from '../../../store/widgets.reducers'
@@ -48,7 +48,9 @@ export function ChooseAmount({
     dispatch(
       setBorrowInfo({
         borrowAmount: currentAmount,
-        borrowAmountBN: upScale(currentAmount, decimals),
+        borrowAmountBN: BigNumber.from(currentAmount)
+          .mul(BigNumber.from(10).pow(decimals))
+          .toJSON(),
         chargedFees,
         nextStep,
       }),

--- a/packages/huma-widget/src/components/CreditLine/borrow/4-Transfer.tsx
+++ b/packages/huma-widget/src/components/CreditLine/borrow/4-Transfer.tsx
@@ -1,6 +1,7 @@
 import { PoolInfoType, txAtom } from '@huma-finance/shared'
 import { useResetAtom } from 'jotai/utils'
 import React, { useCallback } from 'react'
+import { BigNumber } from 'ethers'
 
 import { useAppDispatch, useAppSelector } from '../../../hooks/useRedux'
 import { setStep } from '../../../store/widgets.reducers'
@@ -15,7 +16,9 @@ type Props = {
 export function Transfer({ poolInfo }: Props): React.ReactElement {
   const dispatch = useAppDispatch()
   const reset = useResetAtom(txAtom)
-  const { borrowAmountBN } = useAppSelector(selectWidgetState)
+  const { borrowAmountBN: borrowAmountBNJson } =
+    useAppSelector(selectWidgetState)
+  const borrowAmountBN = BigNumber.from(borrowAmountBNJson)
 
   const handleSuccess = useCallback(() => {
     reset()

--- a/packages/huma-widget/src/components/InvoiceFactoring/borrow/2-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/InvoiceFactoring/borrow/2-ChooseAmount.tsx
@@ -1,10 +1,6 @@
-import {
-  AccountStats,
-  PoolInfoType,
-  upScale,
-  useFeeManager,
-} from '@huma-finance/shared'
+import { AccountStats, PoolInfoType, useFeeManager } from '@huma-finance/shared'
 import React, { useCallback, useState } from 'react'
+import { BigNumber } from 'ethers'
 
 import { useAppDispatch, useAppSelector } from '../../../hooks/useRedux'
 import { setBorrowInfo } from '../../../store/widgets.reducers'
@@ -57,7 +53,9 @@ export function ChooseAmount({
     dispatch(
       setBorrowInfo({
         borrowAmount: currentAmount,
-        borrowAmountBN: upScale(currentAmount, approval?.token.decimal),
+        borrowAmountBN: BigNumber.from(currentAmount)
+          .mul(BigNumber.from(10).pow(BigNumber.from(approval?.token.decimal)))
+          .toJSON(),
         chargedFees,
         remainder: Number(remainder!),
         nextStep: WIDGET_STEP.ConfirmTransfer,

--- a/packages/huma-widget/src/components/StreamFactoring/borrow/2-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/StreamFactoring/borrow/2-ChooseAmount.tsx
@@ -65,7 +65,7 @@ export function ChooseAmount({
       return {
         borrowFlowrate: borrowFlowrate.toString(),
         borrowAmount: Number(newBorrowAmount),
-        borrowAmountBN: newBorrowAmountBN.toString(),
+        borrowAmountBN: newBorrowAmountBN,
       }
     },
     [approval, borrowPeriodInSeconds, currentFlowRate],
@@ -93,7 +93,7 @@ export function ChooseAmount({
     dispatch(
       setBorrowInfo({
         borrowAmount,
-        borrowAmountBN,
+        borrowAmountBN: borrowAmountBN.toJSON(),
         chargedFees,
         nextStep: WIDGET_STEP.ConfirmTransfer,
       }),

--- a/packages/huma-widget/src/components/StreamFactoring/borrow/4-ApproveAllowance.tsx
+++ b/packages/huma-widget/src/components/StreamFactoring/borrow/4-ApproveAllowance.tsx
@@ -1,6 +1,7 @@
 import { PoolInfoType } from '@huma-finance/shared'
 import React, { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
+import { BigNumber } from 'ethers'
 
 import { useAppSelector } from '../../../hooks/useRedux'
 import { setStep } from '../../../store/widgets.reducers'
@@ -16,7 +17,9 @@ export function ApproveAllowance({
   poolInfo,
 }: Props): React.ReactElement | null {
   const dispatch = useDispatch()
-  const { borrowAmountBN } = useAppSelector(selectWidgetState)
+  const { borrowAmountBN: borrowAmountBNJson } =
+    useAppSelector(selectWidgetState)
+  const borrowAmountBN = BigNumber.from(borrowAmountBNJson)
 
   const handleSuccess = useCallback(() => {
     dispatch(setStep(WIDGET_STEP.Permit))

--- a/packages/huma-widget/src/components/StreamFactoring/borrow/5-Permit.tsx
+++ b/packages/huma-widget/src/components/StreamFactoring/borrow/5-Permit.tsx
@@ -8,7 +8,7 @@ import {
   ERC2612_ABI,
   SuperfluidPoolProcessor_ABI,
 } from '@huma-finance/shared'
-import { Contract, ethers } from 'ethers'
+import { BigNumber, Contract, ethers } from 'ethers'
 import React from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -39,20 +39,22 @@ export function Permit({
 }: Props): React.ReactElement | null {
   const dispatch = useDispatch()
   const { address: tokenAddress } = poolInfo.poolUnderlyingToken
-  const { borrowAmountBN, stream } = useAppSelector(selectWidgetState)
+  const { borrowAmountBN: borrowAmountBNJson, stream } =
+    useAppSelector(selectWidgetState)
   const { getERC2612PermitMessage, getTradableStreamPermitMessage } =
     useERC2612Permit()
+  const borrowAmountBN = BigNumber.from(borrowAmountBNJson)
 
   const getApproveAllowanceCallData = async () => {
     const erc2612PermitResult = await getERC2612PermitMessage(
       tokenAddress,
       poolInfo.poolProcessor!,
-      borrowAmountBN!,
+      borrowAmountBN.toString()!,
     )
     const tokenContract = new Contract(tokenAddress, ERC2612_ABI) as Erc2612
     return tokenContract.interface.encodeFunctionData('permit', [
       poolInfo.poolProcessor!,
-      borrowAmountBN!,
+      borrowAmountBN.toString()!,
       erc2612PermitResult.nonce,
       erc2612PermitResult.deadline,
       erc2612PermitResult.v,
@@ -103,7 +105,7 @@ export function Permit({
 
     return poolProcessorContract.interface.encodeFunctionData(
       'mintAndDrawdown',
-      [borrower, borrowAmountBN!, poolInfo.assetAddress!, drawdownEncodedData],
+      [borrower, borrowAmountBN, poolInfo.assetAddress!, drawdownEncodedData],
     )
   }
 

--- a/packages/huma-widget/src/index.tsx
+++ b/packages/huma-widget/src/index.tsx
@@ -62,12 +62,17 @@ type WidgetProps = {
 }
 
 function Widget(props: WCProps<WidgetProps>) {
-  const { children } = props
+  const { children, provider } = props
+
+  let chainId
+  if (provider instanceof JsonRpcProvider) {
+    chainId = provider.network.chainId
+  }
 
   return (
     <ThemeProvider theme={themeHuma}>
       <ReduxProvider store={store}>
-        <Web3Provider {...(props as Web3Props)}>
+        <Web3Provider {...(props as Web3Props)} defaultChainId={chainId}>
           <AtomProvider>
             <ChainSupportProvider>{children}</ChainSupportProvider>
           </AtomProvider>

--- a/packages/huma-widget/src/store/widgets.reducers.ts
+++ b/packages/huma-widget/src/store/widgets.reducers.ts
@@ -52,7 +52,7 @@ export const widgetSlice = createSlice({
         payload,
       }: PayloadAction<{
         borrowAmount: number
-        borrowAmountBN: string
+        borrowAmountBN: JSON
         chargedFees: number
         nextStep: WIDGET_STEP
         remainder?: number
@@ -96,6 +96,7 @@ export const widgetSlice = createSlice({
         payload,
       }: PayloadAction<{ errorMessage: string; errorReason?: string }>,
     ) => {
+      console.trace()
       state.errorMessage = payload.errorMessage
       state.errorReason = payload.errorReason
       state.step = WIDGET_STEP.Error

--- a/packages/huma-widget/src/store/widgets.store.ts
+++ b/packages/huma-widget/src/store/widgets.store.ts
@@ -38,7 +38,7 @@ export type WidgetState = {
   type?: WIDGET_TYPE
   approval?: Approval
   borrowAmount?: number
-  borrowAmountBN?: string
+  borrowAmountBN?: JSON
   chargedFees?: number
   borrowAmountNet?: number
   remainder?: number


### PR DESCRIPTION
- The widget incorrectly attempts to convert BigNumber to number a couple times in the dapp. This causes overflow issues. We'll need to audit the remaining number usages and ensure this isn't being done elsewhere.
- The widget didn't set defaultChainId using the passed in provider. This caused data to be loaded in from Polygon
- Updated borrower address for impactMarket pool