### PR TITLE
Force Bundlr to import the node version

### DIFF
--- a/packages/examples/src/payReceivableWithReferenceId.ts
+++ b/packages/examples/src/payReceivableWithReferenceId.ts
@@ -1,17 +1,17 @@
-import { Wallet, ethers } from "ethers";
-import { ReceivableService } from "@huma-finance/sdk";
-import { ChainEnum } from "@huma-finance/shared";
-require("dotenv").config();
+import { Wallet, ethers } from 'ethers'
+import { ReceivableService } from '@huma-finance/sdk'
+import { ChainEnum } from '@huma-finance/shared'
+require('dotenv').config()
 
 async function main() {
-  const TEST_PRIVATE_KEY = process.env.TEST_PRIVATE_KEY;
+  const TEST_PRIVATE_KEY = process.env.TEST_PRIVATE_KEY
   const provider = new ethers.providers.JsonRpcProvider(
     `https://polygon-mumbai.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_API_KEY}`,
     {
-      name: "Mumbai",
+      name: 'Mumbai',
       chainId: ChainEnum.Mumbai,
-    }
-  );
+    },
+  )
   //   const provider = new ethers.providers.JsonRpcProvider(
   //     `https://goerli.infura.io/v3/${process.env.REACT_APP_INFURA_API_KEY}`,
   //     {
@@ -20,15 +20,15 @@ async function main() {
   //     }
   //   );
 
-  const wallet = new Wallet(TEST_PRIVATE_KEY, provider);
+  const wallet = new Wallet(TEST_PRIVATE_KEY, provider)
 
   const data = await ReceivableService.declareReceivablePaymentByReferenceId(
     wallet,
-    "12345",
-    10 // paymentAmount
-  );
-  const tx = await data.wait();
-  console.log(`Success. Tx hash: ${tx.transactionHash}`);
+    '12345',
+    10, // paymentAmount
+  )
+  const tx = await data.wait()
+  console.log(`Success. Tx hash: ${tx.transactionHash}`)
 }
 
-main();
+main()

--- a/packages/huma-sdk/API.md
+++ b/packages/huma-sdk/API.md
@@ -137,9 +137,9 @@ Note that this does not approve a creditline in Huma's pools and an approve call
 
 * [ARWeaveService](#ARWeaveService) : <code>object</code>
     * [.getBundlrNetworkConfig(chainId)](#ARWeaveService.getBundlrNetworkConfig) ⇒ <code>BundlrConfig</code>
-    * [.getBundlrInstance(config, signer)](#ARWeaveService.getBundlrInstance) ⇒
-    * [.prefundBundlr(config, signer, amount)](#ARWeaveService.prefundBundlr) ⇒ <code>Promise.&lt;FundResponse&gt;</code>
-    * [.storeData(config, signerOrPrivateKey, data, tags, [lazyFund])](#ARWeaveService.storeData) ⇒ <code>Promise.&lt;UploadResponse&gt;</code>
+    * [.getBundlrInstance(config, privateKey)](#ARWeaveService.getBundlrInstance) ⇒
+    * [.prefundBundlr(config, privateKey, amount)](#ARWeaveService.prefundBundlr) ⇒ <code>Promise.&lt;FundResponse&gt;</code>
+    * [.storeData(config, privateKey, data, tags, [lazyFund])](#ARWeaveService.storeData) ⇒ <code>Promise.&lt;UploadResponse&gt;</code>
     * [.queryForMetadata(chainId, sender, referenceId)](#ARWeaveService.queryForMetadata) ⇒ <code>Promise.&lt;any&gt;</code>
     * [.fetchMetadataFromUrl(url)](#ARWeaveService.fetchMetadataFromUrl) ⇒ <code>Promise.&lt;JSON&gt;</code>
     * [.getURIFromARWeaveId(arweaveId)](#ARWeaveService.getURIFromARWeaveId) ⇒ <code>string</code>
@@ -161,7 +161,7 @@ Note that this does not approve a creditline in Huma's pools and an approve call
 
 <a name="ARWeaveService.getBundlrInstance"></a>
 
-### ARWeaveService.getBundlrInstance(config, signer) ⇒
+### ARWeaveService.getBundlrInstance(config, privateKey) ⇒
 <p>Get a Bundlr instance for a specific network</p>
 
 **Kind**: static method of [<code>ARWeaveService</code>](#ARWeaveService)  
@@ -170,11 +170,11 @@ Note that this does not approve a creditline in Huma's pools and an approve call
 | Param | Type | Description |
 | --- | --- | --- |
 | config | <code>BundlrConfig</code> | <p>The configuration for the Bundlr network.</p> |
-| signer | <code>string</code> | <p>The private key of the wallet to use Bundlr with.</p> |
+| privateKey | <code>string</code> | <p>The private key of the wallet to use Bundlr with.</p> |
 
 <a name="ARWeaveService.prefundBundlr"></a>
 
-### ARWeaveService.prefundBundlr(config, signer, amount) ⇒ <code>Promise.&lt;FundResponse&gt;</code>
+### ARWeaveService.prefundBundlr(config, privateKey, amount) ⇒ <code>Promise.&lt;FundResponse&gt;</code>
 <p>Prefund the Bundlr network with the specified amount. Required if not lazy funding.
 Important note: The amount is denominated in the base unit of currency for that network.
 If you want to upload 5 Matic to the Bundlr node, pass in an amount of 5.</p>
@@ -187,12 +187,12 @@ If you want to upload 5 Matic to the Bundlr node, pass in an amount of 5.</p>
 | Param | Type | Description |
 | --- | --- | --- |
 | config | <code>BundlrConfig</code> | <p>The configuration for the Bundlr network.</p> |
-| signer | <code>string</code> | <p>The private key of the wallet to send funds from.</p> |
+| privateKey | <code>string</code> | <p>The private key of the wallet to send funds from.</p> |
 | amount | <code>number</code> | <p>The amount to fund, denoted in whatever currency specified by the config (e.g. MATIC, ETH)</p> |
 
 <a name="ARWeaveService.storeData"></a>
 
-### ARWeaveService.storeData(config, signerOrPrivateKey, data, tags, [lazyFund]) ⇒ <code>Promise.&lt;UploadResponse&gt;</code>
+### ARWeaveService.storeData(config, privateKey, data, tags, [lazyFund]) ⇒ <code>Promise.&lt;UploadResponse&gt;</code>
 <p>Store data on ARWeave using the Bundlr Network.</p>
 
 **Kind**: static method of [<code>ARWeaveService</code>](#ARWeaveService)  
@@ -201,7 +201,7 @@ If you want to upload 5 Matic to the Bundlr node, pass in an amount of 5.</p>
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | config | <code>BundlrConfig</code> |  | <p>Configuration object for the Bundlr instance.</p> |
-| signerOrPrivateKey | <code>Web3Provider</code> \| <code>string</code> |  | <p>Wallet object used for interacting with the Bundlr instance. If calling from a browser, this should be a <code>Web3Provider</code> instance. If calling from a Node.js environment, this should be a private key string.</p> |
+| privateKey | <code>string</code> |  | <p>Private key used for interacting with the Bundlr instance.</p> |
 | data | <code>Record.&lt;string, unknown&gt;</code> |  | <p>The data to store in the Bundlr instance.</p> |
 | tags | <code>Array.&lt;{name: string, value: string}&gt;</code> |  | <p>Array of tag objects with <code>name</code> and <code>value</code> properties.</p> |
 | [lazyFund] | <code>boolean</code> | <code>true</code> | <p>Optional flag to fund the Bundlr instance lazily. If set to <code>false</code>, the Bundlr node should already be funded or else uploads will fail.</p> |
@@ -294,10 +294,10 @@ in Huma's pools that can be drawn down by the borrower.</p>
     * [.declareReceivablePaymentByReferenceId(signer, referenceId, paymentAmount, [gasOpts])](#ReceivableService.declareReceivablePaymentByReferenceId) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
     * [.declareReceivablePaymentByTokenId(signer, receivableTokenId, paymentAmount, [gasOpts])](#ReceivableService.declareReceivablePaymentByTokenId) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
     * [.createReceivable(signer, poolName, poolType, currencyCode, receivableAmount, maturityDate, uri, [gasOpts])](#ReceivableService.createReceivable) ⇒ <code>Promise.&lt;(TransactionResponse\|null)&gt;</code>
-    * [.uploadOrFetchMetadataURI(signerOrProvider, privateKey, chainId, poolName, poolType, metadata, referenceId, extraTags, [lazyFund])](#ReceivableService.uploadOrFetchMetadataURI) ⇒ <code>Promise.&lt;string&gt;</code>
-    * [.createReceivableWithMetadata(signerOrProvider, privateKey, chainId, poolName, poolType, currencyCode, receivableAmount, maturityDate, metadata, referenceId, extraTags, [lazyFund], [gasOpts])](#ReceivableService.createReceivableWithMetadata) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
-    * [.loadReceivablesOfOwnerWithMetadata(signerOrProvider, owner, poolName, poolType, pagination)](#ReceivableService.loadReceivablesOfOwnerWithMetadata) ⇒ <code>Promise.&lt;Array.&lt;RealWorldReceivableInfo&gt;&gt;</code>
-    * [.getTotalCountOfReceivables(signerOrProvider, owner)](#ReceivableService.getTotalCountOfReceivables) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.uploadOrFetchMetadataURI(signer, privateKey, chainId, poolName, poolType, metadata, referenceId, extraTags, [lazyFund])](#ReceivableService.uploadOrFetchMetadataURI) ⇒ <code>Promise.&lt;string&gt;</code>
+    * [.createReceivableWithMetadata(signer, privateKey, chainId, poolName, poolType, currencyCode, receivableAmount, maturityDate, metadata, referenceId, extraTags, [lazyFund], [gasOpts])](#ReceivableService.createReceivableWithMetadata) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
+    * [.loadReceivablesOfOwnerWithMetadata(signer, owner, poolName, poolType, pagination)](#ReceivableService.loadReceivablesOfOwnerWithMetadata) ⇒ <code>Promise.&lt;Array.&lt;RealWorldReceivableInfo&gt;&gt;</code>
+    * [.getTotalCountOfReceivables(signer, owner)](#ReceivableService.getTotalCountOfReceivables) ⇒ <code>Promise.&lt;number&gt;</code>
 
 <a name="ReceivableService.getTokenIdByURI"></a>
 
@@ -383,7 +383,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 <a name="ReceivableService.uploadOrFetchMetadataURI"></a>
 
-### ReceivableService.uploadOrFetchMetadataURI(signerOrProvider, privateKey, chainId, poolName, poolType, metadata, referenceId, extraTags, [lazyFund]) ⇒ <code>Promise.&lt;string&gt;</code>
+### ReceivableService.uploadOrFetchMetadataURI(signer, privateKey, chainId, poolName, poolType, metadata, referenceId, extraTags, [lazyFund]) ⇒ <code>Promise.&lt;string&gt;</code>
 <p>Uploads metadata onto ARWeave (or fetches the existing metadata with the same reference Id) and returns the ARWeave URL</p>
 
 **Kind**: static method of [<code>ReceivableService</code>](#ReceivableService)  
@@ -393,8 +393,8 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| signerOrProvider | <code>Web3Provider</code> \| <code>ethers.Signer</code> |  | <p>If calling this function from a browser, this function expects a Web3Provider. If calling this function from a server, this function expects an ethers Signer. Note that privateKey only needs to be included from server calls.</p> |
-| privateKey | <code>string</code> \| <code>null</code> |  | <p>Private key of the wallet used to upload metadata to ARWeave. Only required if calling this function from a server.</p> |
+| signer | <code>ethers.Signer</code> |  | <p>An ethers.signer instance used to de-dupe metadata uploads.</p> |
+| privateKey | <code>string</code> |  | <p>Private key of the wallet used to upload metadata to ARWeave.</p> |
 | chainId | <code>number</code> |  | <p>The chain ID to mint the receivable token on and pay ARWeave funds from.</p> |
 | poolName | <code>POOL\_NAME</code> |  | <p>The pool name. Used to lookup the pool address to pay to.</p> |
 | poolType | <code>POOL\_TYPE</code> |  | <p>The pool type. Used to lookup the pool address to pay to.</p> |
@@ -405,7 +405,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 <a name="ReceivableService.createReceivableWithMetadata"></a>
 
-### ReceivableService.createReceivableWithMetadata(signerOrProvider, privateKey, chainId, poolName, poolType, currencyCode, receivableAmount, maturityDate, metadata, referenceId, extraTags, [lazyFund], [gasOpts]) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
+### ReceivableService.createReceivableWithMetadata(signer, privateKey, chainId, poolName, poolType, currencyCode, receivableAmount, maturityDate, metadata, referenceId, extraTags, [lazyFund], [gasOpts]) ⇒ <code>Promise.&lt;TransactionResponse&gt;</code>
 <p>Creates a RealWorldReceivable token with metadata uploaded onto ARWeave</p>
 
 **Kind**: static method of [<code>ReceivableService</code>](#ReceivableService)  
@@ -415,8 +415,8 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| signerOrProvider | <code>Web3Provider</code> \| <code>ethers.Signer</code> |  | <p>If calling this function from a browser, this function expects a Web3Provider. If calling this function from a server, this function expects an ethers Signer. Note that privateKey only needs to be included from server calls.</p> |
-| privateKey | <code>string</code> \| <code>null</code> |  | <p>Private key of the wallet used to upload metadata to ARWeave. Only required if calling this function from a server.</p> |
+| signer | <code>ethers.Signer</code> |  | <p>An ethers.signer instance used to de-dupe metadata uploads.</p> |
+| privateKey | <code>string</code> |  | <p>Private key of the wallet used to upload metadata to ARWeave.</p> |
 | chainId | <code>number</code> |  | <p>The chain ID to mint the receivable token on and pay ARWeave funds from.</p> |
 | poolName | <code>POOL\_NAME</code> |  | <p>The pool name. Used to lookup the pool address to pay to.</p> |
 | poolType | <code>POOL\_TYPE</code> |  | <p>The pool type. Used to lookup the pool address to pay to.</p> |
@@ -431,7 +431,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 <a name="ReceivableService.loadReceivablesOfOwnerWithMetadata"></a>
 
-### ReceivableService.loadReceivablesOfOwnerWithMetadata(signerOrProvider, owner, poolName, poolType, pagination) ⇒ <code>Promise.&lt;Array.&lt;RealWorldReceivableInfo&gt;&gt;</code>
+### ReceivableService.loadReceivablesOfOwnerWithMetadata(signer, owner, poolName, poolType, pagination) ⇒ <code>Promise.&lt;Array.&lt;RealWorldReceivableInfo&gt;&gt;</code>
 <p>Loads all RWRs belonging to the specified owner, including the RWR metadata</p>
 
 **Kind**: static method of [<code>ReceivableService</code>](#ReceivableService)  
@@ -441,7 +441,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 | Param | Type | Description |
 | --- | --- | --- |
-| signerOrProvider | <code>Web3Provider</code> \| <code>ethers.Signer</code> | <p>If calling this function from a browser, this function expects a Web3Provider. If calling this function from a server, this function expects an ethers Signer. Note that privateKey only needs to be included from server calls.</p> |
+| signer | <code>ethers.Signer</code> | <p>An ethers.signer instance used to de-dupe metadata uploads.</p> |
 | owner | <code>string</code> | <p>The receivable token owner to query from.</p> |
 | poolName | <code>POOL\_NAME</code> | <p>The pool name. Used to lookup the pool address to pay to.</p> |
 | poolType | <code>POOL\_TYPE</code> | <p>The pool type. Used to lookup the pool address to pay to.</p> |
@@ -449,7 +449,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 <a name="ReceivableService.getTotalCountOfReceivables"></a>
 
-### ReceivableService.getTotalCountOfReceivables(signerOrProvider, owner) ⇒ <code>Promise.&lt;number&gt;</code>
+### ReceivableService.getTotalCountOfReceivables(signer, owner) ⇒ <code>Promise.&lt;number&gt;</code>
 <p>Get the total count of all RWRs belonging to the specified owner</p>
 
 **Kind**: static method of [<code>ReceivableService</code>](#ReceivableService)  
@@ -459,7 +459,7 @@ in Huma's pools that can be drawn down by the borrower.</p>
 
 | Param | Type | Description |
 | --- | --- | --- |
-| signerOrProvider | <code>Web3Provider</code> \| <code>ethers.Signer</code> | <p>If calling this function from a browser, this function expects a Web3Provider. If calling this function from a server, this function expects an ethers Signer. Note that privateKey only needs to be included from server calls.</p> |
+| signer | <code>ethers.Signer</code> | <p>An ethers.signer instance used to de-dupe metadata uploads.</p> |
 | owner | <code>string</code> | <p>The receivable token owner to query from.</p> |
 
 <a name="SubgraphService"></a>

--- a/packages/huma-sdk/babel.config.js
+++ b/packages/huma-sdk/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env'],
+}

--- a/packages/huma-sdk/jest.config.js
+++ b/packages/huma-sdk/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.(js|jsx)$': 'babel-jest',
   },
   coverageReporters: ['json-summary', 'text', 'lcov'],
   transformIgnorePatterns: ['<rootDir>/node_modules/'],

--- a/packages/huma-sdk/package.json
+++ b/packages/huma-sdk/package.json
@@ -22,7 +22,7 @@
     "test:badges": "yarn run test:coverage && yarn jest-coverage-badges"
   },
   "dependencies": {
-    "@bundlr-network/client": "0.11.9",
+    "@bundlr-network/client": "0.11.17",
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/bignumber": "^5.6.0",
     "@ethersproject/constants": "^5.7.0",

--- a/packages/huma-sdk/src/services/ARWeaveService.ts
+++ b/packages/huma-sdk/src/services/ARWeaveService.ts
@@ -1,4 +1,4 @@
-import Bundlr from '@bundlr-network/client'
+import Bundlr from '@bundlr-network/client/build/cjs/node/bundlr'
 import type {
   FundResponse,
   UploadResponse,

--- a/packages/huma-sdk/src/services/ARWeaveService.ts
+++ b/packages/huma-sdk/src/services/ARWeaveService.ts
@@ -77,14 +77,14 @@ export function getBundlrNetworkConfig(chainId: number): BundlrConfig {
  * @function
  * @memberof ARWeaveService
  * @param {BundlrConfig} config - The configuration for the Bundlr network.
- * @param {string} signer - The private key of the wallet to use Bundlr with.
+ * @param {string} privateKey - The private key of the wallet to use Bundlr with.
  * @returns The Bundlr instance
  */
-async function getBundlrInstance(config: BundlrConfig, signer: string) {
+async function getBundlrInstance(config: BundlrConfig, privateKey: string) {
   const bundlr = new Bundlr(
     config.nodeUrl,
     config.currency,
-    signer,
+    privateKey,
     config.providerUrl
       ? {
           providerUrl: config.providerUrl,
@@ -105,20 +105,20 @@ async function getBundlrInstance(config: BundlrConfig, signer: string) {
  * @function
  * @memberof ARWeaveService
  * @param {BundlrConfig} config - The configuration for the Bundlr network.
- * @param {string} signer - The private key of the wallet to send funds from.
+ * @param {string} privateKey - The private key of the wallet to send funds from.
  * @param {number} amount - The amount to fund, denoted in whatever currency specified by the config (e.g. MATIC, ETH)
  * @returns {Promise<FundResponse>} - The fund response.
  */
 async function prefundBundlr(
   config: BundlrConfig,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signer: string,
+  privateKey: string,
   amount: number,
 ): Promise<FundResponse> {
   const bundlr = new Bundlr(
     config.nodeUrl,
     config.currency,
-    signer,
+    privateKey,
     config.providerUrl
       ? {
           providerUrl: config.providerUrl,
@@ -140,9 +140,7 @@ async function prefundBundlr(
  * @function
  * @memberof ARWeaveService
  * @param {BundlrConfig} config - Configuration object for the Bundlr instance.
- * @param {Web3Provider | string} signerOrPrivateKey - Wallet object used for interacting with the Bundlr instance.
- *         If calling from a browser, this should be a `Web3Provider` instance. If calling from a Node.js
- *         environment, this should be a private key string.
+ * @param {string} privateKey - Private key used for interacting with the Bundlr instance.
  * @param {Record<string, unknown>} data - The data to store in the Bundlr instance.
  * @param {Array<{ name: string, value: string }>} tags - Array of tag objects with `name` and `value` properties.
  * @param {boolean} [lazyFund=true] - Optional flag to fund the Bundlr instance lazily. If set to `false`, the
@@ -151,7 +149,7 @@ async function prefundBundlr(
  */
 async function storeData(
   config: BundlrConfig,
-  signerOrPrivateKey: Web3Provider | string,
+  privateKey: Web3Provider | string,
   data: Record<string, unknown>,
   tags: { name: string; value: string }[],
   lazyFund: boolean = true,
@@ -159,7 +157,7 @@ async function storeData(
   const bundlr = new Bundlr(
     config.nodeUrl,
     config.currency,
-    signerOrPrivateKey,
+    privateKey,
     config.providerUrl
       ? {
           providerUrl: config.providerUrl,

--- a/packages/huma-sdk/tests/services/ARWeaveService.test.ts
+++ b/packages/huma-sdk/tests/services/ARWeaveService.test.ts
@@ -8,7 +8,7 @@ import BN from 'bignumber.js'
 
 import { ARWeaveService, BundlrConfig } from '../../src/services/ARWeaveService'
 
-jest.mock('@bundlr-network/client', () => {
+jest.mock('@bundlr-network/client/build/cjs/node/bundlr', () => {
   class Bundlr {
     nodeUrl: string
 
@@ -110,7 +110,8 @@ describe('getBundlrInstance', () => {
       providerUrl:
         'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
     }
-    const signer = 'privateKey'
+    const signer =
+      '0000000000000000000000000000000000000000000000000000000000000000'
 
     const bundlrInstance = await ARWeaveService.getBundlrInstance(
       config,
@@ -124,10 +125,11 @@ describe('getBundlrInstance', () => {
 
   it('should create a Bundlr instance without a providerUrl if not provided in the config', async () => {
     const config = {
-      nodeUrl: 'https://devnet.bundlr.network',
+      nodeUrl: 'https://bundlr.network',
       currency: 'ethereum',
     }
-    const signer = 'privateKey'
+    const signer =
+      '0000000000000000000000000000000000000000000000000000000000000000'
 
     const bundlrInstance = await ARWeaveService.getBundlrInstance(
       config,
@@ -148,7 +150,8 @@ describe('prefundBundlr', () => {
       providerUrl:
         'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
     }
-    const signer = '0x123'
+    const signer =
+      '0000000000000000000000000000000000000000000000000000000000000000'
     const amount = 10
 
     const result = await ARWeaveService.prefundBundlr(config, signer, amount)
@@ -156,17 +159,17 @@ describe('prefundBundlr', () => {
     expect(result).toEqual(BigNumber.from(String(amount * amount ** 18)))
   })
 
-  it('should prefund the Bundlr network if providerUrl is empty', async () => {
+  it('should not prefund the Bundlr network if providerUrl is empty', async () => {
     const config: BundlrConfig = {
       nodeUrl: 'https://devnet.bundlr.network',
       currency: 'ethereum',
       providerUrl: '',
     }
-    const signer = '0x123'
+    const signer =
+      '0000000000000000000000000000000000000000000000000000000000000000'
     const amount = 10
 
     const result = await ARWeaveService.prefundBundlr(config, signer, amount)
-
     expect(result).toEqual(BigNumber.from(String(amount * amount ** 18)))
   })
 })
@@ -181,7 +184,8 @@ describe('storeData', () => {
       providerUrl:
         'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
     }
-    const signer = '0x123'
+    const signer =
+      '0000000000000000000000000000000000000000000000000000000000000000'
     // byteLength 15
     const data = { key: 'value' }
     const tags = [{ name: 'tag1', value: 'value1' }]
@@ -206,7 +210,8 @@ describe('storeData', () => {
 describe('queryForMetadata', () => {
   it('should query for metadata from the Arweave network', async () => {
     const chainId = 5
-    const sender = '0x123'
+    const sender =
+      '0000000000000000000000000000000000000000000000000000000000000000'
     const referenceId = 'ref1'
 
     // Mock the request function to resolve with specific data

--- a/packages/huma-sdk/tests/services/ReceivableService.test.ts
+++ b/packages/huma-sdk/tests/services/ReceivableService.test.ts
@@ -213,7 +213,7 @@ describe('declareReceivablePaymentByReferenceId', () => {
       'ARWeave id',
     )
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: ['receivable1', 'receivable2'],
+      rwreceivables: ['receivable1', 'receivable2'],
     })
 
     const signer = {
@@ -247,7 +247,7 @@ describe('declareReceivablePaymentByReferenceId', () => {
       'ARWeave id',
     )
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: 12 }],
+      rwreceivables: [{ tokenId: 12 }],
     })
     ;(getRealWorldReceivableContract as jest.Mock).mockReturnValue(undefined)
 
@@ -281,7 +281,7 @@ describe('declareReceivablePaymentByReferenceId', () => {
       'ARWeave id',
     )
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: null }],
+      rwreceivables: [{ tokenId: null }],
     })
     ;(getRealWorldReceivableContract as jest.Mock).mockReturnValue(undefined)
 
@@ -316,7 +316,7 @@ describe('declareReceivablePaymentByReferenceId', () => {
     )
     ;(ARWeaveService.getURIFromARWeaveId as jest.Mock).mockReturnValue('uri')
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: 'receivable1' }],
+      rwreceivables: [{ tokenId: 'receivable1' }],
     })
     ;(getDefaultGasOptions as jest.Mock).mockResolvedValue({})
     ;(getRealWorldReceivableContract as jest.Mock).mockReturnValue({
@@ -650,7 +650,7 @@ describe('createReceivableWithMetadata', () => {
     ;(ARWeaveService.storeData as jest.Mock).mockReturnValue({})
     const signer = { getAddress: jest.fn().mockResolvedValue('0x123') } as any
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: null }],
+      rwreceivables: [{ tokenId: null }],
     })
 
     const privateKey = '0xabc'
@@ -701,7 +701,7 @@ describe('createReceivableWithMetadata', () => {
     ;(ARWeaveService.getURIFromARWeaveId as jest.Mock).mockReturnValue('uri')
     const signer = { getAddress: jest.fn().mockResolvedValue('0x123') } as any
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: 'receivable1' }],
+      rwreceivables: [{ tokenId: 'receivable1' }],
     })
 
     const privateKey = '0xabc'
@@ -770,7 +770,7 @@ describe('createReceivableWithMetadata', () => {
       }),
     })
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: null }],
+      rwreceivables: [{ tokenId: null }],
     })
 
     const signer = { getAddress: jest.fn().mockResolvedValue('0x123') } as any
@@ -817,7 +817,7 @@ describe('createReceivableWithMetadata', () => {
       createRealWorldReceivable: () => true,
     })
     ;(request as jest.Mock).mockResolvedValue({
-      receivables: [{ tokenId: null }],
+      rwreceivables: [{ tokenId: null }],
     })
 
     const signer = { getAddress: jest.fn().mockResolvedValue('0xNull') } as any

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,10 +1564,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bundlr-network/client@0.11.9":
-  version "0.11.9"
-  resolved "https://registry.yarnpkg.com/@bundlr-network/client/-/client-0.11.9.tgz#c6d170e1ff74661af78547ed8bd8d84e09824f4a"
-  integrity sha512-0lZAB0kx+GZsIGPT+nN2tMLseAzg98hS1HEupRoZcuE9OoMOa4+H+SOTNEbmxp7kuDKoMC3TXN9GOJBXFcPe7Q==
+"@bundlr-network/client@0.11.17":
+  version "0.11.17"
+  resolved "https://registry.yarnpkg.com/@bundlr-network/client/-/client-0.11.17.tgz#33822c0c56f328742ef3ec3107e371892b5b8282"
+  integrity sha512-DZHNvX+IeQASxCk4ldnlqpn/51KHDGiGXbhWPiMt2c1bLGdSnyOZoTv+MYnGv6Px0ZYqYcotur1Vyu3Fc3aSMw==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/contracts" "^5.7.0"
@@ -1581,8 +1581,8 @@
     "@supercharge/promise-pool" "^2.1.0"
     algosdk "^1.13.1"
     aptos "^1.8.5"
-    arbundles "^0.9.7"
-    arweave "=1.11.8"
+    arbundles "^0.9.9"
+    arweave "=1.11.9"
     async-retry "^1.3.3"
     axios "^0.25.0"
     base64url "^3.0.1"
@@ -7488,10 +7488,10 @@ aptos@^1.8.5:
     form-data "4.0.0"
     tweetnacl "1.0.3"
 
-arbundles@^0.9.7:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/arbundles/-/arbundles-0.9.8.tgz#d02e1151aa1cac75e33058a67f65a627e6a669c5"
-  integrity sha512-UevirqeqzCSLPlgyxvn7vvuRm22+wAK+HXCYGnE1HTytgfAu8so/g41wkUziNzoeeTNmodJpEy6RbRfYOaRsTA==
+arbundles@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/arbundles/-/arbundles-0.9.9.tgz#3b4d6c215a9d022e0805e294287280b2f64fe5c4"
+  integrity sha512-2//u+DW2fDGC+5y2gaM4M4Q+Lx6V71YgVvMF869m41eHYPZZC4OU+Oq2iJpcONv7uao9kvVHE8f1VknmW5GpAQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/hash" "^5.7.0"
@@ -7723,6 +7723,18 @@ arweave@=1.11.8:
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.11.8.tgz#09376e0c6cec40a661cbb27a306cb11c0a663cd8"
   integrity sha512-58ODeNPIC4OjaOCl2bXjKbOFGsiVZFs+DkQg3BvQGvFWNqw1zTJ4Jp01xGUz+GbdOaDyJcCC0g3l0HwdJfFPyw==
+  dependencies:
+    arconnect "^0.4.2"
+    asn1.js "^5.4.1"
+    axios "^0.27.2"
+    base64-js "^1.5.1"
+    bignumber.js "^9.0.2"
+    util "^0.12.4"
+
+arweave@=1.11.9:
+  version "1.11.9"
+  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.11.9.tgz#4d1fc17052e4e6d6eeb8fd18063b43eca52f2a56"
+  integrity sha512-i+oQQkQgjASG/+iS/BVq0JDhpW0jLGMtiqPwfHe0x46YCnuA23prN82EW4KigxZAphF9jNzDexQjGLAKbhw4Zw==
   dependencies:
     arconnect "^0.4.2"
     asn1.js "^5.4.1"


### PR DESCRIPTION
We typically allow Bundlr to detect its environment and decide whether to import a node-supported Bundlr (server side) or a web-supported Bundlr (for web browser interaction). ImpactMarkets is having difficulties with Bundlr loading in the WebBundlr instance on AWS Lambda, which errors out because WebBundlr expects crypto libraries to be available usually imported by browsers. I'm going to force the Bundlr import to import the NodeBundlr instance and remove WebBundlr support since nobody using our SDK has had a use case for web browser backed receivable metadata creation.