### PR TITLE
Fix dep conflict

### DIFF
--- a/packages/huma-shared/package.json
+++ b/packages/huma-shared/package.json
@@ -38,7 +38,7 @@
     "@mui/system": "^5.0.6",
     "@mui/x-date-pickers": "^5.0.7",
     "@reduxjs/toolkit": "^1.8.6",
-    "@requestnetwork/multi-format": "^0.15.10",
+    "@requestnetwork/multi-format": "0.15.10",
     "@types/utf8": "^3.0.1",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/jsonrpc-http-connection": "^1.0.3",


### PR DESCRIPTION
Request network changed their package in a minor version update to require a different version of node. This is a breaking change for us so I'm requiring 0.15.10
https://github.com/RequestNetwork/requestNetwork/blame/f1d7ec4c01c2f464e4894531c0dfd18995e6ce52/packages/multi-format/package.json