### PR TITLE
Require different wallets for receivable uploading and arweave uploading

### DIFF
--- a/packages/huma-sdk/src/services/v2/HumaReceivableFactory.ts
+++ b/packages/huma-sdk/src/services/v2/HumaReceivableFactory.ts
@@ -45,6 +45,17 @@ export class HumaReceivableFactory {
       throw new Error('Input must be a JSON object.')
     }
 
+    // Check that the private key is different from the signer passed in the context
+    const signerAddress = await this.#humaContext.signer.getAddress()
+    const arweavePaymentAddress = ethers.utils.computeAddress(
+      arweavePaymentPrivateKey,
+    )
+    if (signerAddress === arweavePaymentAddress) {
+      throw new Error(
+        'The ARWeave payment private key must be different from the signer address',
+      )
+    }
+
     await this.throwIfReferenceIdExists(referenceId)
 
     const metadataURI = await this.uploadMetadata(

--- a/packages/huma-sdk/tests/services/v2/HumaReceivableFactory.test.ts
+++ b/packages/huma-sdk/tests/services/v2/HumaReceivableFactory.test.ts
@@ -1,0 +1,41 @@
+import { ChainEnum, POOL_NAME, POOL_TYPE } from '@huma-finance/shared'
+import { BigNumber, ethers } from 'ethers'
+import { HumaReceivableFactory, HumaContext } from '../../../src/services'
+
+describe('HumaReceivableFactory', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should throw if the signer and arweave uploader wallet are the same', async () => {
+    const mnemonic =
+      'test test test test test test test test test test test junk'
+    const mnemonicWallet = ethers.Wallet.fromMnemonic(mnemonic)
+    const provider = new ethers.providers.JsonRpcProvider(
+      `http://localhost:8545`,
+    )
+
+    const humaContext = new HumaContext({
+      signer: mnemonicWallet,
+      provider,
+      chainId: ChainEnum.Localhost,
+      poolName: POOL_NAME.ArfCreditPoolV2,
+      poolType: POOL_TYPE.ReceivableBackedCreditLine,
+    })
+    const receivableFactory = new HumaReceivableFactory({
+      humaContext,
+    })
+
+    await expect(
+      receivableFactory.createReceivableWithMetadata(
+        mnemonicWallet.privateKey, // privateKey
+        840, // currencyCode for USD
+        BigNumber.from(1000), // receivableAmount
+        1684517656, // maturityDate
+        JSON.parse('{"test": "test"}'),
+      ),
+    ).rejects.toThrow(
+      'The ARWeave payment private key must be different from the signer address',
+    )
+  })
+})


### PR DESCRIPTION
As part of our security backlog, we want to require a different wallet to upload ARWeave data than the one minting a receivable because ARWeave requires passing in a wallet private key directly.