### PR TITLE
loop solana tx confirm status

### DIFF
--- a/packages/huma-shared/src/utils/env.ts
+++ b/packages/huma-shared/src/utils/env.ts
@@ -1,5 +1,5 @@
 export const checkIsDev = () =>
-  !process.env.REACT_APP_FORCE_IS_DEV_FALSE &&
+  process.env.REACT_APP_FORCE_IS_DEV_FALSE !== 'true' &&
   !!(
     window.location.hostname.startsWith('dev') ||
     window.location.hostname.startsWith('v2') ||


### PR DESCRIPTION
As Alchemy doesn't support wss which is used to update the transaction confirm status, we use loop to get signature status instead