### PR TITLE
Handle 0 liquidity cap when clicking max in supply

### DIFF
--- a/packages/huma-widget/src/components/Lend/solanaSupply/4-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/Lend/solanaSupply/4-ChooseAmount.tsx
@@ -45,7 +45,10 @@ export function ChooseAmount({
     const juniorTrancheAssetsBN = new BN(juniorTrancheAssets ?? 0)
     const seniorTrancheAssetsBN = new BN(seniorTrancheAssets ?? 0)
     const totalDeployedBN = seniorTrancheAssetsBN.add(juniorTrancheAssetsBN)
-    const totalAvailableCapBN = new BN(liquidityCap ?? 0).sub(totalDeployedBN)
+    let totalAvailableCapBN = new BN(liquidityCap ?? 0).sub(totalDeployedBN)
+    totalAvailableCapBN = totalAvailableCapBN.ltn(0)
+      ? new BN(0)
+      : totalAvailableCapBN
     const maxSeniorAssetsBN = juniorTrancheAssetsBN.muln(
       maxSeniorJuniorRatio ?? 0,
     )

--- a/packages/huma-widget/src/components/Lend/stellarSupply/3-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/Lend/stellarSupply/3-ChooseAmount.tsx
@@ -41,7 +41,9 @@ export function ChooseAmount({
     const juniorTrancheAssetsBN = BigInt(juniorTrancheAssets ?? 0)
     const seniorTrancheAssetsBN = BigInt(seniorTrancheAssets ?? 0)
     const totalDeployedBN = seniorTrancheAssetsBN + juniorTrancheAssetsBN
-    const totalAvailableCapBN = BigInt(liquidityCap ?? 0) - totalDeployedBN
+    let totalAvailableCapBN = BigInt(liquidityCap ?? 0) - totalDeployedBN
+    totalAvailableCapBN =
+      totalAvailableCapBN < 0 ? BigInt(0) : totalAvailableCapBN
     const maxSeniorAssetsBN =
       juniorTrancheAssetsBN * BigInt(maxSeniorJuniorRatio ?? 0)
     let seniorAvailableCapBN = maxSeniorAssetsBN - seniorTrancheAssetsBN

--- a/packages/huma-widget/src/components/Lend/supplyV2/4-ChooseAmount.tsx
+++ b/packages/huma-widget/src/components/Lend/supplyV2/4-ChooseAmount.tsx
@@ -48,7 +48,10 @@ export function ChooseAmount({
   const { juniorAvailableCapBN, seniorAvailableCapBN } = useMemo(() => {
     const { maxSeniorJuniorRatio, liquidityCap: liquidityCapBN } = lpConfig
     const totalDeployedBN = seniorAssetsBN.add(juniorAssetsBN)
-    const totalAvailableCapBN = liquidityCapBN.sub(totalDeployedBN)
+    let totalAvailableCapBN = liquidityCapBN.sub(totalDeployedBN)
+    totalAvailableCapBN = totalAvailableCapBN.lt(0)
+      ? BigNumber.from(0)
+      : totalAvailableCapBN
     const maxSeniorAssetsBN = juniorAssetsBN.mul(maxSeniorJuniorRatio)
     let seniorAvailableCapBN = maxSeniorAssetsBN.sub(seniorAssetsBN)
     seniorAvailableCapBN = seniorAvailableCapBN.gt(totalAvailableCapBN)


### PR DESCRIPTION
Verified clicking max supply on a liquidity cap 0 pool worked for EVM + Solana

<img width="609" alt="Screen Shot 2024-12-10 at 4 14 50 PM" src="https://github.com/user-attachments/assets/0474f9f3-8612-4230-8bd6-41cf12fa2eae">

