### PR TITLE
Hardcode CU limit for deposit

### DIFF
--- a/packages/huma-sdk/API.md
+++ b/packages/huma-sdk/API.md
@@ -72,6 +72,9 @@ Note that this does not approve a creditline in Huma's pools and an approve call
 <dd><p>Get the chain ID from a signer or provider object.</p></dd>
 <dt><a href="#getPoolInfo">getPoolInfo(poolName, poolType)</a> ⇒ <code>PoolInfoType</code> | <code>undefined</code></dt>
 <dd><p>Returns the pool info based on the provided pool name and type, using the same chain ID as the provider/signer given</p></dd>
+<dt><a href="#isSetComputeLimitInstruction">isSetComputeLimitInstruction()</a></dt>
+<dd><p>Check if a given instruction is a SetComputeUnitLimit instruction
+See https://github.com/solana-program/compute-budget/blob/main/clients/js/src/generated/programs/computeBudget.ts#L29</p></dd>
 </dl>
 
 ## Typedefs
@@ -919,6 +922,13 @@ Note that this does not approve a creditline in Huma's pools and an approve call
 | poolName | <code>POOL\_NAME</code> | <p>The name of the pool.</p> |
 | poolType | <code>POOL\_TYPE</code> | <p>The type of the pool.</p> |
 
+<a name="isSetComputeLimitInstruction"></a>
+
+## isSetComputeLimitInstruction()
+<p>Check if a given instruction is a SetComputeUnitLimit instruction
+See https://github.com/solana-program/compute-budget/blob/main/clients/js/src/generated/programs/computeBudget.ts#L29</p>
+
+**Kind**: global function  
 <a name="IrysConstructorArgs"></a>
 
 ## IrysConstructorArgs : <code>Object</code>

--- a/packages/huma-widget/src/components/Lend/solanaWithdraw/2-Transfer.tsx
+++ b/packages/huma-widget/src/components/Lend/solanaWithdraw/2-Transfer.tsx
@@ -14,7 +14,7 @@ import {
   TokenInvalidAccountOwnerError,
 } from '@solana/spl-token'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import { PublicKey, Transaction } from '@solana/web3.js'
+import { ComputeBudgetProgram, PublicKey, Transaction } from '@solana/web3.js'
 import React, { useCallback, useEffect, useState } from 'react'
 import useLogOnFirstMount from '../../../hooks/useLogOnFirstMount'
 import { useAppDispatch } from '../../../hooks/useRedux'
@@ -102,6 +102,12 @@ export function Transfer({
           })
           .transaction()
         tx.add(disburseTx)
+
+        tx.instructions.unshift(
+          ComputeBudgetProgram.setComputeUnitLimit({
+            units: 60_000,
+          }),
+        )
       } else {
         const withdrawAfterPoolClosureTx = await program.methods
           .withdrawAfterPoolClosure()

--- a/packages/huma-widget/src/components/SolanaTxSendModal.tsx
+++ b/packages/huma-widget/src/components/SolanaTxSendModal.tsx
@@ -91,18 +91,22 @@ export function SolanaTxSendModal({
         // Extract writable accounts
         const txAccounts = extractWritableAccounts(txCopy)
         // Add on compute unit limit + price instructions
-        const optimizedTx = await buildOptimalTransactionFromConnection(
+        const {
+          tx: optimizedTx,
+          unitsConsumed,
+          fee,
+        } = await buildOptimalTransactionFromConnection(
           txCopy,
           txAccounts,
           connection,
           chainId,
           publicKey,
           useHighPriority ? 'High' : undefined,
-          process.env.REACT_APP_HELIUS_API_KEY,
+          import.meta.env.REACT_APP_HELIUS_API_KEY,
         )
         loggingHelper.logAction('SigningTransaction', {
-          priceData: optimizedTx.instructions[0].data,
-          unitsData: optimizedTx.instructions[1].data,
+          priorityFee: fee,
+          computeUnitLimit: unitsConsumed,
           recentBlockhash: optimizedTx.recentBlockhash,
           lastValidBlockHeight: optimizedTx.lastValidBlockHeight,
         })


### PR DESCRIPTION
There seems to be a race condition in our deposit simulation where the RPC simulates the CreateLenderAccounts instruction first, but those accounts aren't immediately available in the Deposit instruction, so Deposit doesn't consume any CU. This has caused a handful of transactions to fail, but it's super flaky and hard to pinpoint.

Under Helius' recommendation, I'm adding a hardcoded limit here, and only simulating CU limit if a CU limit instruction doesn't already exist.