### PR TITLE
Log chain and flow type in datadog funnel logging

### DIFF
--- a/packages/huma-web-shared/src/utils/datadogLogger.ts
+++ b/packages/huma-web-shared/src/utils/datadogLogger.ts
@@ -30,34 +30,7 @@ export const initRUMLogger = () => {
   }
 }
 
-// Explicitly defining the actions type so we can funnel
-// based on expected values and avoid typos
-export type LoggingActions =
-  | 'StartFlow'
-  | 'ExitFlow'
-  | 'Evaluation'
-  | 'ApproveLender'
-  | 'ChooseTranche'
-  | 'ChooseAmount'
-  | 'ApproveAllowance'
-  | 'Transaction'
-  | 'SigningTransaction'
-  | 'SendingTransaction'
-  | 'TransactionError'
-  | 'TransactionSuccess'
-  | 'ConfirmTransfer'
-  | 'ShowRetryScreenDueToExpiration'
-  | 'UnknownError'
-  | 'Success'
-  | 'PointsEarned'
-  | 'SetInitialStep'
-  | 'ConnectWallet'
-  | 'KYCKYBApproved'
-  | 'AgreementAccepted'
-  | 'Accredited'
-  | 'CloseNotifi'
-  | 'OpenNotifi'
-export const logActionRaw = (action: LoggingActions, context?: Object) => {
+export const logActionRaw = (action: string, context?: Object) => {
   if (ddLoggerEnabled) {
     datadogRum.addAction(action, { ...context })
   }
@@ -82,7 +55,31 @@ export type LoggingContext = {
   poolName: POOL_NAME
   poolType: POOL_TYPE
   chainId: ChainEnum | SolanaChainEnum | StellarChainEnum
+  chainType: 'EVM' | 'Solana' | 'Stellar'
 }
+
+// Explicitly defining the actions type so we can funnel
+// based on expected values and avoid typos
+export type LoggingActions =
+  | 'StartFlow'
+  | 'ExitFlow'
+  | 'Evaluation'
+  | 'ApproveLender'
+  | 'ChooseTranche'
+  | 'ChooseAmount'
+  | 'ApproveAllowance'
+  | 'Transaction'
+  | 'SigningTransaction'
+  | 'SendingTransaction'
+  | 'TransactionError'
+  | 'TransactionSuccess'
+  | 'ConfirmTransfer'
+  | 'ShowRetryScreenDueToExpiration'
+  | 'UnknownError'
+  | 'Success'
+  | 'PointsEarned'
+  | 'SetInitialStep'
+
 export class LoggingContextHelper {
   #context: LoggingContext | null
 
@@ -92,7 +89,9 @@ export class LoggingContextHelper {
 
   logAction(action: LoggingActions, additionalContext: Object) {
     logActionRaw(
-      action,
+      this.#context
+        ? `${this.#context.chainType}-${this.#context.flow}-${action}`
+        : action,
       this.#context
         ? { ...this.#context, ...additionalContext }
         : additionalContext,

--- a/packages/huma-widget/src/components/Lend/solanaSupply/index.tsx
+++ b/packages/huma-widget/src/components/Lend/solanaSupply/index.tsx
@@ -105,6 +105,7 @@ export function SolanaLendSupply({
         chainId: poolInfo.chainId,
         poolName: poolInfo.poolName,
         poolType: poolInfo.poolType,
+        chainType: 'Solana',
       }
       const loggingHelperInit = new LoggingContextHelper(context)
       loggingHelperInit.logAction('StartFlow', {})

--- a/packages/huma-widget/src/components/Lend/solanaWithdraw/index.tsx
+++ b/packages/huma-widget/src/components/Lend/solanaWithdraw/index.tsx
@@ -96,6 +96,7 @@ export function SolanaLendWithdraw({
         chainId: poolInfo.chainId,
         poolName: poolInfo.poolName,
         poolType: poolInfo.poolType,
+        chainType: 'Solana',
       }
       const loggingHelperInit = new LoggingContextHelper(context)
       loggingHelperInit.logAction('StartFlow', {})


### PR DESCRIPTION
Instead of logging `TransactionSuccess`, log `Solana-Supply-TransactionSuccess` so we can better breakdown funnel by user flows

<img width="1058" alt="Screen Shot 2025-03-11 at 12 50 37 PM" src="https://github.com/user-attachments/assets/e6d29e8a-1886-48e7-97d9-1478185cd275" />
